### PR TITLE
rust/: Add support for QUIC (libp2p-0.51)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -12,7 +12,7 @@ trap "kill 0" EXIT
 TcpTransportSecurityProtocols=( noise plaintext )
 
 echo "# Start Rust and Golang servers."
-./rust/target/release/server --private-key-pkcs8 rust/test.pk8 --listen-address /ip4/127.0.0.1/udp/9992/quic-v1 2>&1 &
+./rust/target/release/server --private-key-pkcs8 rust/test.pk8 --listen-address /ip4/127.0.0.1/udp/9992/quic 2>&1 &
 ./golang/go-libp2p-perf --fake-crypto-seed --listen-address /ip4/0.0.0.0/udp/9993/quic --tcp-transport-security noise > /dev/null 2>&1 &
 ./golang/go-libp2p-perf --fake-crypto-seed --listen-address /ip4/0.0.0.0/udp/9994/quic --tcp-transport-security plaintext > /dev/null 2>&1 &
 
@@ -24,7 +24,7 @@ for Protocol in ${TcpTransportSecurityProtocols[*]}
 do
     echo
     #echo "## Transport security $Protocol"
-    ./rust/target/release/client --server-address /ip4/127.0.0.1/udp/9992/quic-v1 --tcp-transport-security $Protocol
+    ./rust/target/release/client --server-address /ip4/127.0.0.1/udp/9992/quic --tcp-transport-security $Protocol
     break # FIXME
 done
 
@@ -34,10 +34,10 @@ echo
 echo "# Rust -> Golang"
 echo
 # echo "## Transport security noise"
-./rust/target/release/client --server-address /ip4/127.0.0.1/udp/9993/quic-v1 --tcp-transport-security noise
+./rust/target/release/client --server-address /ip4/127.0.0.1/udp/9993/quic --tcp-transport-security noise
 echo
 # echo "## Transport security plaintext"
-# ./rust/target/release/client --server-address /ip4/127.0.0.1/udp/9994/quic-v1 --tcp-transport-security plaintext
+# ./rust/target/release/client --server-address /ip4/127.0.0.1/udp/9994/quic --tcp-transport-security plaintext
 
 echo
 echo "# Golang -> Rust"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libp2p = { version = "0.50.0", default-features = false, features = ["async-std", "dns", "macros", "noise", "plaintext", "rsa", "tcp", "yamux"] }
-futures_codec = "0.4"
+libp2p = { version = "0.51.0", git = "https://github.com/libp2p/rust-libp2p.git", branch = "master", default-features = false, features = ["async-std", "dns", "macros", "noise", "plaintext", "rsa", "tcp", "yamux"] }
+either = "1"
 futures = "0.3.1"
 async-std = { version = "1.12.0", features = ["attributes"] }
 bytes = "1.3.0"

--- a/rust/src/bin/client.rs
+++ b/rust/src/bin/client.rs
@@ -39,7 +39,7 @@ async fn main() {
     loop {
         match client.next().await.expect("Infinite stream.") {
             SwarmEvent::Behaviour(e) => {
-                println!("{}", e);
+                println!("{e}");
 
                 // TODO: Fix hack
                 //

--- a/rust/src/bin/server.rs
+++ b/rust/src/bin/server.rs
@@ -41,12 +41,12 @@ async fn main() {
 
     poll_fn(|cx| loop {
         match server.poll_next_unpin(cx) {
-            Poll::Ready(Some(e)) => println!("{:?}", e),
+            Poll::Ready(Some(e)) => println!("{e:?}"),
             Poll::Ready(None) => panic!("Unexpected server termination."),
             Poll::Pending => {
                 if !listening {
                     if let Some(a) = Swarm::listeners(&server).next() {
-                        println!("Listening on {:?}.", a);
+                        println!("Listening on {a:?}.");
                         listening = true;
                     }
                 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -154,7 +154,8 @@ pub fn build_transport(
     };
 
     let quic_transport = {
-        let config = QuicConfig::new(&keypair);
+        let mut config = QuicConfig::new(&keypair);
+        config.support_draft_29 = true;
         QuicTransport::new(config)
     };
 


### PR DESCRIPTION

@mxinden for some reason rust node fails to connect to go node:

```
# Rust -> Golang

Local peer id: PeerId("12D3KooWLRCL1GFnr2CaApGLtrrDXKR6sXQXRCD5hXtJDfT18zbL")
thread 'async-std/runtime' panicked at 'listener upgrade error Upgrade(Select(ProtocolError(IoError(Custom { kind: ConnectionReset, error: Reset(0) }))))', src/handler.rs:288:17
```
